### PR TITLE
chore: update uuid to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 base64 = "0.6"
-uuid = { version = "0.4", features = ["serde", "v4"] }
+uuid = { version = "0.5", features = ["serde", "v4"] }
 


### PR DESCRIPTION
Updated `uuid` to avoid multiple serde versions in depencency tree

`cargo tree -d` on master
```
serde v0.9.15
└── uuid v0.4.0
    └── rustwt v1.0.1 (file:///home/mike/dev/devheap/rustwt)

serde v1.0.15
├── rustwt v1.0.1 (file:///home/mike/dev/devheap/rustwt)
└── serde_json v1.0.3
    └── rustwt v1.0.1 (file:///home/mike/dev/devheap/rustwt) (*)
```